### PR TITLE
Update Mix.php to prevent runtime error

### DIFF
--- a/src/Mix.php
+++ b/src/Mix.php
@@ -15,6 +15,9 @@ use misterbk\mix\variables\MixVariable;
 
 use Craft;
 use craft\base\Plugin;
+use craft\web\twig\variables\CraftVariable;
+
+use yii\base\Event;
 
 class Mix extends Plugin
 {
@@ -32,6 +35,15 @@ class Mix extends Plugin
         parent::init();
         self::$plugin = $this;
 
+        Event::on(
+            CraftVariable::class,
+            CraftVariable::EVENT_INIT,
+            function (Event $event) {
+                $variable = $event->sender;
+                $variable->set('mix', MixVariable::class);
+            }
+        );
+        
         Craft::$app->view->twig->addExtension(new MixTwigExtension());
 
         Craft::info('Mix plugin loaded', __METHOD__);


### PR DESCRIPTION
Without this addition, this plugin throws the following runtime error:

`Calling unknown method: craft\web\twig\variables\CraftVariable::mix()`

There might be another way to prevent this, let me know!