### PR TITLE
Allow use of relative path to asset directory

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -27,7 +27,14 @@ class Settings extends Model
      */
     public $assetPath = 'assets';
 
-
+    
+    /**
+     * Use relative path to the asset directory.
+     *
+     * @var string
+     */
+    public $useRelativePath = false;
+    
     /**
      * @inheritdoc
      */
@@ -36,6 +43,7 @@ class Settings extends Model
         return [
             [['publicPath', 'assetPath'], 'required'],
             [['publicPath', 'assetPath'], 'string'],
+            [['useRelativePath'], 'boolean'],
         ];
     }
 }

--- a/src/services/MixService.php
+++ b/src/services/MixService.php
@@ -38,7 +38,14 @@ class MixService extends Component
      * @var string
      */
     protected $assetPath;
-
+    
+    /**
+     * Use a relative path to the asset directory.
+     *
+     * @var string
+     */
+    protected $useRelativePath;
+    
     /**
      * Name of the manifest file.
      *
@@ -60,7 +67,8 @@ class MixService extends Component
     public function init()
     {
         $settings = Mix::$plugin->getSettings();
-
+        
+        $this->useRelativePath = $settings->useRelativePath;
         $this->rootPath = rtrim(CRAFT_BASE_PATH, '/');
         $this->publicPath = trim($settings->publicPath, '/');
         $this->assetPath = trim($settings->assetPath, '/');
@@ -91,7 +99,7 @@ class MixService extends Component
             $file = $manifest[$fileKey];
         }
 
-        return '/' . implode('/', array_filter([
+        return ($this->useRelativePath ? '' : '/') . implode('/', array_filter([
             $this->assetPath,
             ltrim($file, '/')
         ]));

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -28,6 +28,17 @@
     required: true
 }) }}
 
+
+{{ forms.lightswitchField({
+    label: 'Relative Path',
+    instructions: 'The path of the asset directory will be relative to the public directory. Useful if your site is not with in the web root of your server.',
+    id: 'useRelativePath',
+    name: 'useRelativePath',
+    value: true,
+    required: false,
+    on: (settings.useRelativePath is defined) ? settings.useRelativePath : ""
+}) }}
+
 <hr>
 
 <h3>Plugin Usage</h3>


### PR DESCRIPTION
This is useful if the current site install is not in with in web root. Allows the useRelativePath setting to be set with in an environment config if necessary as well.