### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Mix.php
+++ b/src/Mix.php
@@ -45,7 +45,7 @@ class Mix extends Plugin
             }
         );
 
-        Craft::$app->view->twig->addExtension(new MixTwigExtension());
+        Craft::$app->view->registerTwigExtension(new MixTwigExtension());
 
         Craft::info('Mix plugin loaded', __METHOD__);
     }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.