### PR TITLE
Craft CMS 4.0 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   ],
   "require": {
-    "craftcms/cms": "^3.0.0-RC1|^4.0.0-beta.1"
+    "craftcms/cms": "^4.0.0-alpha"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   ],
   "require": {
-    "craftcms/cms": "^3.0.0-RC1"
+    "craftcms/cms": "^3.0.0-RC1|^4.0.0-beta.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/Mix.php
+++ b/src/Mix.php
@@ -53,7 +53,7 @@ class Mix extends Plugin
     /**
      * @inheritdoc
      */
-    protected function createSettingsModel()
+    protected function createSettingsModel(): ?\craft\base\Model
     {
         return new Settings();
     }
@@ -61,7 +61,7 @@ class Mix extends Plugin
     /**
      * @inheritdoc
      */
-    protected function settingsHtml(): string
+    protected function settingsHtml(): ?string
     {
         return Craft::$app->view->renderTemplate(
             'mix/settings',

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -31,7 +31,7 @@ class Settings extends Model
     /**
      * @inheritdoc
      */
-    public function rules()
+    public function rules(): array
     {
         return [
             [['publicPath', 'assetPath'], 'required'],

--- a/src/services/MixService.php
+++ b/src/services/MixService.php
@@ -64,7 +64,7 @@ class MixService extends Component
     /**
      * @inheritdoc
      */
-    public function init()
+    public function init(): void
     {
         $settings = Mix::$plugin->getSettings();
 

--- a/src/twigextensions/MixTwigExtension.php
+++ b/src/twigextensions/MixTwigExtension.php
@@ -15,7 +15,7 @@ use Twig_Extension;
 use Twig_SimpleFilter;
 use Twig_SimpleFunction;
 
-class MixTwigExtension extends Twig_Extension
+class MixTwigExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * @inheritdoc
@@ -31,7 +31,7 @@ class MixTwigExtension extends Twig_Extension
     public function getFilters()
     {
         return [
-            new Twig_SimpleFilter('mix', [$this, 'mix']),
+            new \Twig\TwigFilter('mix', [$this, 'mix']),
         ];
     }
 
@@ -41,7 +41,7 @@ class MixTwigExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('mix', [$this, 'mix']),
+            new \Twig\TwigFunction('mix', [$this, 'mix']),
         ];
     }
 


### PR DESCRIPTION
I forked this repo and ran the Rector rules detailed [here](https://craftcms.com/docs/4.x/extend/updating-plugins.html) to allow support for Craft CMS 4.0. I'm running it locally on a site I'm developing and it works fine with those changes.